### PR TITLE
prevent leaking internal urls to external sites

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file("."))
   .enablePlugins(SbtPlugin)
   .settings(
     name := "sbt-test-report",
-    version := "0.19.0",
+    version := "0.20.0",
     libraryDependencies ++= Dependencies.compile,
     sbtPlugin := true,
     isPublicArtefact := true

--- a/src/main/scala/uk/gov/hmrc/testreport/TestReportPlugin.scala
+++ b/src/main/scala/uk/gov/hmrc/testreport/TestReportPlugin.scala
@@ -149,7 +149,7 @@ object TestReportPlugin extends AutoPlugin {
                   p(
                     if (isJenkinsBuild) a(href := jenkinsBuildUrl, s"#$jenkinsBuildId") else "Local build",
                     " of ",
-                    a(href := s"https://github.com/hmrc/$projectName", target := "_blank", projectName),
+                    a(href := s"https://github.com/hmrc/$projectName", target := "_blank" rel := "noreferrer noopener", projectName),
                     " on ",
                     time(attr("datetime") := htmlDateTime, readableDateTime),
                     s" ($browser)"
@@ -230,6 +230,7 @@ object TestReportPlugin extends AutoPlugin {
                                 a(
                                   href := helpUrl,
                                   target := "_blank",
+                                  rel := "noreferrer noopener",
                                   helpUrl
                                 )
                               )
@@ -276,7 +277,7 @@ object TestReportPlugin extends AutoPlugin {
                 cls := "repel region wrapper",
                 p(
                   "© 2023 ",
-                  a(href := s"https://github.com/hmrc/$projectName", target := "_blank", projectName)
+                  a(href := s"https://github.com/hmrc/$projectName", target := "_blank", rel := "noreferrer noopener", projectName)
                 ),
                 nav(
                   attr("aria-label") := "secondary navigation",
@@ -287,14 +288,15 @@ object TestReportPlugin extends AutoPlugin {
                       a(
                         href := "https://github.com/hmrc/accessibility/blob/main/README.md",
                         target := "_blank",
+                        rel := "noreferrer noopener",
                         "Guidance"
                       )
                     ),
                     li(
-                      a(href := "https://hmrcdigital.slack.com/archives/C4JQESR8U", target := "_blank", "Support")
+                      a(href := "https://hmrcdigital.slack.com/archives/C4JQESR8U", target := "_blank", rel := "noreferrer noopener", "Support")
                     ),
                     li(
-                      a(href := "https://forms.gle/T39z8o6rjfLyHym99", target := "_blank", "Feedback")
+                      a(href := "https://forms.gle/T39z8o6rjfLyHym99", target := "_blank", rel := "noreferrer noopener", "Feedback")
                     ),
                     li(
                       a(href := "#", "Back to top")

--- a/src/main/scala/uk/gov/hmrc/testreport/TestReportPlugin.scala
+++ b/src/main/scala/uk/gov/hmrc/testreport/TestReportPlugin.scala
@@ -149,7 +149,7 @@ object TestReportPlugin extends AutoPlugin {
                   p(
                     if (isJenkinsBuild) a(href := jenkinsBuildUrl, s"#$jenkinsBuildId") else "Local build",
                     " of ",
-                    a(href := s"https://github.com/hmrc/$projectName", target := "_blank" rel := "noreferrer noopener", projectName),
+                    a(href := s"https://github.com/hmrc/$projectName", target := "_blank", rel := "noreferrer noopener", projectName),
                     " on ",
                     time(attr("datetime") := htmlDateTime, readableDateTime),
                     s" ($browser)"


### PR DESCRIPTION
add `rel="noreferrer noopener"` to report links, so that we don't link internal build urls in referrers. The `noopener` is implied when the link is `target="_blank"` in modern browsers but might as well include both, `noopener` prevents reverse tabnapping where page you open could redirect the opening page to a phishing site